### PR TITLE
Update dependencies

### DIFF
--- a/packages/dart_pptx/lib/src/archive/input_file_stream.dart
+++ b/packages/dart_pptx/lib/src/archive/input_file_stream.dart
@@ -317,7 +317,7 @@ class InputFileStream extends InputStreamBase {
   }
 
   @override
-  Uint8List toUint8List() {
+  Uint8List toUint8List([Uint8List? bytes]) {
     if (isEOS) {
       return Uint8List(0);
     }

--- a/packages/dart_pptx/lib/src/classes/images.g.dart
+++ b/packages/dart_pptx/lib/src/classes/images.g.dart
@@ -22,4 +22,5 @@ Map<String, dynamic> _$ImageReferenceToJson(ImageReference instance) =>
       'isAsset': instance.isAsset,
       'isFile': instance.isFile,
       'ext': instance.ext,
+      'hashCode': instance.hashCode,
     };

--- a/packages/dart_pptx/lib/src/classes/slide.g.dart
+++ b/packages/dart_pptx/lib/src/classes/slide.g.dart
@@ -20,6 +20,4 @@ Map<String, dynamic> _$SlideToJson(Slide instance) => <String, dynamic>{
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
     };

--- a/packages/dart_pptx/lib/src/slides/agenda.g.dart
+++ b/packages/dart_pptx/lib/src/slides/agenda.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideAgendaToJson(SlideAgenda instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'title': instance.title?.toJson(),
       'subtitle': instance.subtitle?.toJson(),
       'topics': instance.topics?.toJson(),

--- a/packages/dart_pptx/lib/src/slides/big_fact.g.dart
+++ b/packages/dart_pptx/lib/src/slides/big_fact.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideBigFactToJson(SlideBigFact instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'information': instance.information?.toJson(),
       'fact': instance.fact?.toJson(),
       'layoutId': instance.layoutId,

--- a/packages/dart_pptx/lib/src/slides/blank.g.dart
+++ b/packages/dart_pptx/lib/src/slides/blank.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideBlankToJson(SlideBlank instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'layoutId': instance.layoutId,
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/bullets.g.dart
+++ b/packages/dart_pptx/lib/src/slides/bullets.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideBulletsToJson(SlideBullets instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'bullets': instance.bullets.map((e) => e.toJson()).toList(),
       'layoutId': instance.layoutId,
       'source': instance.source,

--- a/packages/dart_pptx/lib/src/slides/photo.g.dart
+++ b/packages/dart_pptx/lib/src/slides/photo.g.dart
@@ -22,7 +22,5 @@ Map<String, dynamic> _$SlidePhotoToJson(SlidePhoto instance) =>
       'hasNotes': instance.hasNotes,
       'image': instance.image?.toJson(),
       'layoutId': instance.layoutId,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/photo_3_up.g.dart
+++ b/packages/dart_pptx/lib/src/slides/photo_3_up.g.dart
@@ -24,7 +24,5 @@ Map<String, dynamic> _$SlidePhoto3UpToJson(SlidePhoto3Up instance) =>
       'image2': instance.image2?.toJson(),
       'image3': instance.image3?.toJson(),
       'layoutId': instance.layoutId,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/quote.g.dart
+++ b/packages/dart_pptx/lib/src/slides/quote.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideQuoteToJson(SlideQuote instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'attribution': instance.attribution?.toJson(),
       'quote': instance.quote?.toJson(),
       'layoutId': instance.layoutId,

--- a/packages/dart_pptx/lib/src/slides/section.g.dart
+++ b/packages/dart_pptx/lib/src/slides/section.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideSectionToJson(SlideSection instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'section': instance.section?.toJson(),
       'layoutId': instance.layoutId,
       'source': instance.source,

--- a/packages/dart_pptx/lib/src/slides/statement.g.dart
+++ b/packages/dart_pptx/lib/src/slides/statement.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideStatementToJson(SlideStatement instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'statement': instance.statement?.toJson(),
       'layoutId': instance.layoutId,
       'source': instance.source,

--- a/packages/dart_pptx/lib/src/slides/title.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideTitleToJson(SlideTitle instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'title': instance.title?.toJson(),
       'author': instance.author?.toJson(),
       'layoutId': instance.layoutId,

--- a/packages/dart_pptx/lib/src/slides/title_and_bullets.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title_and_bullets.g.dart
@@ -21,8 +21,6 @@ Map<String, dynamic> _$SlideTitleAndBulletsToJson(
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'bullets': instance.bullets.map((e) => e.toJson()).toList(),
       'title': instance.title?.toJson(),
       'subtitle': instance.subtitle?.toJson(),

--- a/packages/dart_pptx/lib/src/slides/title_and_photo.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title_and_photo.g.dart
@@ -25,7 +25,5 @@ Map<String, dynamic> _$SlideTitleAndPhotoToJson(SlideTitleAndPhoto instance) =>
       'author': instance.author?.toJson(),
       'subtitle': instance.subtitle?.toJson(),
       'layoutId': instance.layoutId,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/title_and_photo_alt.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title_and_photo_alt.g.dart
@@ -25,7 +25,5 @@ Map<String, dynamic> _$SlideTitleAndPhotoAltToJson(
       'title': instance.title?.toJson(),
       'subtitle': instance.subtitle?.toJson(),
       'layoutId': instance.layoutId,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/title_bullets_and_photo.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title_bullets_and_photo.g.dart
@@ -26,7 +26,5 @@ Map<String, dynamic> _$SlideTitleBulletsAndPhotoToJson(
       'title': instance.title?.toJson(),
       'subtitle': instance.subtitle?.toJson(),
       'layoutId': instance.layoutId,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'source': instance.source,
     };

--- a/packages/dart_pptx/lib/src/slides/title_only.g.dart
+++ b/packages/dart_pptx/lib/src/slides/title_only.g.dart
@@ -20,8 +20,6 @@ Map<String, dynamic> _$SlideTitleOnlyToJson(SlideTitleOnly instance) =>
       'notesId': instance.notesId,
       'background': instance.background.toJson(),
       'hasNotes': instance.hasNotes,
-      'imageRefs':
-          instance.imageRefs.map((k, e) => MapEntry(k.toString(), e?.toJson())),
       'title': instance.title?.toJson(),
       'subtitle': instance.subtitle?.toJson(),
       'layoutId': instance.layoutId,

--- a/packages/dart_pptx/lib/src/version.dart
+++ b/packages/dart_pptx/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.0';
+const packageVersion = '0.1.2+1';

--- a/packages/dart_pptx/pubspec.yaml
+++ b/packages/dart_pptx/pubspec.yaml
@@ -23,20 +23,20 @@ funding:
   - https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=WSH3GVC49GNNJ
 
 dependencies:
-  archive: ^3.3.6
-  collection: ^1.17.0
-  file: ^6.1.4
-  http: ^0.13.5
+  archive: ^3.4.2
+  collection: ^1.18.0
+  file: ^7.0.0
+  http: ^1.1.0
   image_size_getter: ^2.1.2
-  json_annotation: ^4.8.0
+  json_annotation: ^4.8.1
   mustache_template: ^2.0.0
-  path: ^1.8.2
+  path: ^1.8.3
   recase: ^4.1.0
 
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.0
   flutter_lints: ^2.0.0
-  build_runner: ^2.3.3
-  json_serializable: ^6.6.1
+  build_runner: ^2.4.6
+  json_serializable: ^6.7.1
   build_version: ^2.1.1

--- a/packages/flutter_pptx/pubspec.yaml
+++ b/packages/flutter_pptx/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   flutter:
     sdk: flutter
   dart_pptx: ^0.1.2+1
-  screenshot: ^1.3.0
+  screenshot: ^2.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Updates dependencies and implementation to make the library compatible with `archive: 3.4.2` and `Flutter 3.13.x`.

- Bumped the package versions overall to the current latest.

- `toUint8List` method of the `InputStreamBase` class that is imported from the `archive` package now accepts an optional `Uint8List` property, which is now implemented in the `InputFileStream` class implementation.

- `RenderView` class on the most recent Flutter version doesn't accept the `window` property, which is still provided in `screenshot: 1.3.0`. Hence, updated this package to version `2.1.0`.

- Ran the `dart run build_runner build` on the `dart_pptx`, hence there are updates resultant from `json_serializable`.

Related Issue: https://github.com/rodydavis/flutter_pptx/issues/5